### PR TITLE
Check knownConfig for null before calling isEnabled on it

### DIFF
--- a/app/src/main/java/com/wireguard/android/ConfigManager.java
+++ b/app/src/main/java/com/wireguard/android/ConfigManager.java
@@ -347,7 +347,7 @@ public class ConfigManager extends Service
         private ConfigUpdater(final Config knownConfig, final Config newConfig) {
             this.knownConfig = knownConfig;
             this.newConfig = newConfig.copy();
-            this.newConfig.setIsEnabled(this.knownConfig.isEnabled());
+            this.newConfig.setIsEnabled(knownConfig != null ? knownConfig.isEnabled() : false);
             newName = newConfig.getName();
             // When adding a config, "old file" and "new file" are the same thing.
             oldName = knownConfig != null ? knownConfig.getName() : newName;


### PR DESCRIPTION
This change fixes a small oversight in the constructor of ConfigUpdater, where isEnabled could be called on a null object (e.g. when you add a new configuration and knownConfig is passed as null).
This also sets the configs to be disabled by default after creation.